### PR TITLE
Severity Levels & Log Format

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     unicode-display_width (1.3.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -81,6 +82,7 @@ DEPENDENCIES
   rubocop (~> 0.47)
   rubocop-rspec (~> 1.13)
   simplecov (~> 0.13)
+  timecop (~> 0.9)
 
 BUNDLED WITH
    1.16.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To log an informative message to STDOUT, use the following code snippet:
 Logman.info("Hello World")
 
 # Output:
-# event='Hello World'
+# level='I' time='2017-12-11 09:47:27 +0000' event='Hello World'
 ```
 
 Every log event can be extended with metadata — a hash with key value pairs:
@@ -30,7 +30,7 @@ Every log event can be extended with metadata — a hash with key value pairs:
 Logman.info("Hello World", :from => "renderedtext", :to => "The World")
 
 # Output:
-# event='Hello World' from='renderedtext' to='The World'
+# level='I' time='2017-12-11 09:47:27 +0000' event='Hello World' from='renderedtext' to='The World'
 ```
 
 Every log event has a severity. In the previous examples we have used `info`. To
@@ -40,7 +40,23 @@ log an `error` use the following snippet:
 Logman.error("Team does not exists", :owner => "renderedtext", :team_name => "z-fightes")
 
 # Output:
-# event='Team does not exists' owner='renderedtext' team_name='z-fighters'
+# level='E' time='2017-12-11 09:47:27 +0000' event='Team does not exists' owner='renderedtext' team_name='z-fighters'
+```
+
+Logman supports multiple severity levels:
+
+``` ruby
+Logman.fatal("Hello")
+Logman.error("Hello")
+Logman.warn("Hello")
+Logman.info("Hello")
+Logman.debug("Hello")
+```
+
+Where the following hierarchy stands:
+
+``` txt
+FATAL > ERROR > WARN > INFO > DEBUG
 ```
 
 ## Instantiated Loggers
@@ -90,18 +106,18 @@ end
 In case of a successful processing of a video, we would see the following:
 
 ``` txt
-event='started' id='31312' title='Keyboard Cat' component='video_processor'
-event='loaded into memory' component='video_processor' id='31312' title='Keyboard Cat' size='3123131312'
-event='compressed' component='video_processor' id='31312' title='Keyboard Cat' size='12312312'
-event='upload_to_s3' component='video_processor' id='31312' title='Keyboard Cat' s3_path='s3://random'
-event='finished' component='video_processor' id='31312' title='Keyboard Cat'
+level='I' time='2017-12-11 09:47:27 +0000' event='started' id='31312' title='Keyboard Cat' component='video_processor'
+level='I' time='2017-12-11 09:47:27 +0000' event='loaded into memory' component='video_processor' id='31312' title='Keyboard Cat' size='3123131312'
+level='I' time='2017-12-11 09:47:27 +0000' event='compressed' component='video_processor' id='31312' title='Keyboard Cat' size='12312312'
+level='I' time='2017-12-11 09:47:27 +0000' event='upload_to_s3' component='video_processor' id='31312' title='Keyboard Cat' s3_path='s3://random'
+level='I' time='2017-12-11 09:47:27 +0000' event='finished' component='video_processor' id='31312' title='Keyboard Cat'
 ```
 
 In case of an error, we would see the following:
 
 ``` txt
-event='started' id='31312' title='Keyboard Cat' component='video_processor'
-event='failed' component='video_processor' id='31312' title='Keyboard Cat' message='Out of memory'
+level='I' time='2017-12-11 09:47:27 +0000' event='started' id='31312' title='Keyboard Cat' component='video_processor'
+level='E' time='2017-12-11 09:47:27 +0000' event='failed' component='video_processor' id='31312' title='Keyboard Cat' message='Out of memory'
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To log an informative message to STDOUT, use the following code snippet:
 Logman.info("Hello World")
 
 # Output:
-# level='I' time='2017-12-11 09:47:27 +0000' event='Hello World'
+# level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World'
 ```
 
 Every log event can be extended with metadata — a hash with key value pairs:
@@ -30,7 +30,7 @@ Every log event can be extended with metadata — a hash with key value pairs:
 Logman.info("Hello World", :from => "renderedtext", :to => "The World")
 
 # Output:
-# level='I' time='2017-12-11 09:47:27 +0000' event='Hello World' from='renderedtext' to='The World'
+# level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='renderedtext' to='The World'
 ```
 
 Every log event has a severity. In the previous examples we have used `info`. To
@@ -40,7 +40,7 @@ log an `error` use the following snippet:
 Logman.error("Team does not exists", :owner => "renderedtext", :team_name => "z-fightes")
 
 # Output:
-# level='E' time='2017-12-11 09:47:27 +0000' event='Team does not exists' owner='renderedtext' team_name='z-fighters'
+# level='E' time='2017-12-11 09:47:27 +0000' pid='1234' event='Team does not exists' owner='renderedtext' team_name='z-fighters'
 ```
 
 Logman supports multiple severity levels:
@@ -106,18 +106,18 @@ end
 In case of a successful processing of a video, we would see the following:
 
 ``` txt
-level='I' time='2017-12-11 09:47:27 +0000' event='started' id='31312' title='Keyboard Cat' component='video_processor'
-level='I' time='2017-12-11 09:47:27 +0000' event='loaded into memory' component='video_processor' id='31312' title='Keyboard Cat' size='3123131312'
-level='I' time='2017-12-11 09:47:27 +0000' event='compressed' component='video_processor' id='31312' title='Keyboard Cat' size='12312312'
-level='I' time='2017-12-11 09:47:27 +0000' event='upload_to_s3' component='video_processor' id='31312' title='Keyboard Cat' s3_path='s3://random'
-level='I' time='2017-12-11 09:47:27 +0000' event='finished' component='video_processor' id='31312' title='Keyboard Cat'
+level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='started' id='31312' title='Keyboard Cat' component='video_processor'
+level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='loaded into memory' component='video_processor' id='31312' title='Keyboard Cat' size='3123131312'
+level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='compressed' component='video_processor' id='31312' title='Keyboard Cat' size='12312312'
+level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='upload_to_s3' component='video_processor' id='31312' title='Keyboard Cat' s3_path='s3://random'
+level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='finished' component='video_processor' id='31312' title='Keyboard Cat'
 ```
 
 In case of an error, we would see the following:
 
 ``` txt
-level='I' time='2017-12-11 09:47:27 +0000' event='started' id='31312' title='Keyboard Cat' component='video_processor'
-level='E' time='2017-12-11 09:47:27 +0000' event='failed' component='video_processor' id='31312' title='Keyboard Cat' message='Out of memory'
+level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='started' id='31312' title='Keyboard Cat' component='video_processor'
+level='E' time='2017-12-11 09:47:27 +0000' pid='1234' event='failed' component='video_processor' id='31312' title='Keyboard Cat' message='Out of memory'
 ```
 
 ## Development

--- a/lib/logman.rb
+++ b/lib/logman.rb
@@ -1,5 +1,35 @@
 require "logman/version"
+require "logger"
 
 module Logman
-  # Your code goes here...
+  DEFAULT_LOGGER = Logger.new(STDOUT)
+  DEFAULT_LOGGER.formatter = proc do |severity, datetime, progname, msg|
+    event = { :level => severity[0].upcase, :time => datetime }.merge(msg)
+
+    "#{Logman.format(event)}\n"
+  end
+
+  def self.fatal(message)
+    DEFAULT_LOGGER.fatal(:event => message)
+  end
+
+  def self.error(message)
+    DEFAULT_LOGGER.error(:event => message)
+  end
+
+  def self.warn(message)
+    DEFAULT_LOGGER.warn(:event => message)
+  end
+
+  def self.info(message)
+    DEFAULT_LOGGER.info(:event => message)
+  end
+
+  def self.debug(message)
+    DEFAULT_LOGGER.debug(:event => message)
+  end
+
+  def self.format(event_hash)
+    event_hash.map { |key, value| "#{key}='#{value}'" }.join(" ")
+  end
 end

--- a/lib/logman.rb
+++ b/lib/logman.rb
@@ -9,24 +9,24 @@ module Logman
     "#{Logman.format(event)}\n"
   end
 
-  def self.fatal(message)
-    DEFAULT_LOGGER.fatal(:event => message)
+  def self.fatal(message, metadata = {})
+    DEFAULT_LOGGER.fatal({:event => message}.merge(metadata))
   end
 
-  def self.error(message)
-    DEFAULT_LOGGER.error(:event => message)
+  def self.error(message, metadata = {})
+    DEFAULT_LOGGER.error({:event => message}.merge(metadata))
   end
 
-  def self.warn(message)
-    DEFAULT_LOGGER.warn(:event => message)
+  def self.warn(message, metadata = {})
+    DEFAULT_LOGGER.warn({:event => message}.merge(metadata))
   end
 
-  def self.info(message)
-    DEFAULT_LOGGER.info(:event => message)
+  def self.info(message, metadata = {})
+    DEFAULT_LOGGER.info({:event => message}.merge(metadata))
   end
 
-  def self.debug(message)
-    DEFAULT_LOGGER.debug(:event => message)
+  def self.debug(message, metadata = {})
+    DEFAULT_LOGGER.debug({:event => message}.merge(metadata))
   end
 
   def self.format(event_hash)

--- a/lib/logman.rb
+++ b/lib/logman.rb
@@ -3,30 +3,34 @@ require "logger"
 
 module Logman
   DEFAULT_LOGGER = Logger.new(STDOUT)
-  DEFAULT_LOGGER.formatter = proc do |severity, datetime, progname, msg|
-    event = { :level => severity[0].upcase, :time => datetime }.merge(msg)
+  DEFAULT_LOGGER.formatter = proc do |severity, datetime, _progname, msg|
+    event = {
+      :level => severity[0].upcase,
+      :time => datetime,
+      :pid => Process.pid
+    }.merge(msg)
 
     "#{Logman.format(event)}\n"
   end
 
   def self.fatal(message, metadata = {})
-    DEFAULT_LOGGER.fatal({:event => message}.merge(metadata))
+    DEFAULT_LOGGER.fatal({ :event => message }.merge(metadata))
   end
 
   def self.error(message, metadata = {})
-    DEFAULT_LOGGER.error({:event => message}.merge(metadata))
+    DEFAULT_LOGGER.error({ :event => message }.merge(metadata))
   end
 
   def self.warn(message, metadata = {})
-    DEFAULT_LOGGER.warn({:event => message}.merge(metadata))
+    DEFAULT_LOGGER.warn({ :event => message }.merge(metadata))
   end
 
   def self.info(message, metadata = {})
-    DEFAULT_LOGGER.info({:event => message}.merge(metadata))
+    DEFAULT_LOGGER.info({ :event => message }.merge(metadata))
   end
 
   def self.debug(message, metadata = {})
-    DEFAULT_LOGGER.debug({:event => message}.merge(metadata))
+    DEFAULT_LOGGER.debug({ :event => message }.merge(metadata))
   end
 
   def self.format(event_hash)

--- a/logman.gemspec
+++ b/logman.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.47"
   spec.add_development_dependency "rubocop-rspec", "~> 1.13"
   spec.add_development_dependency "reek", "~> 4.5"
+  spec.add_development_dependency "timecop", "~> 0.9"
 end

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -1,11 +1,18 @@
 RSpec.describe Logman do
+  around(:each) do |example|
+    # make it easy to test time values in output
+    Timecop.freeze(2017, 12, 11, 9, 47, 27) do
+      example.run
+    end
+  end
+
   it "has a version number" do
     expect(Logman::VERSION).not_to be nil
   end
 
   describe ".fatal" do
     it "displays a fatal message to STDOUT" do
-      msg = "level='F' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+      msg = "level='F' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
 
       expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
     end
@@ -13,33 +20,33 @@ RSpec.describe Logman do
 
   describe ".error" do
     it "displays an error message to STDOUT" do
-      msg = "level='E' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+      msg = "level='E' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
 
-      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+      expect { Logman.error("Hello World") }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".warn" do
     it "displays an warning message to STDOUT" do
-      msg = "level='W' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+      msg = "level='W' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
 
-      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+      expect { Logman.warn("Hello World") }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".info" do
     it "displays an info message to STDOUT" do
-      msg = "level='I' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+      msg = "level='I' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
 
-      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+      expect { Logman.info("Hello World") }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".debug" do
     it "displays a debug message to STDOUT" do
-      msg = "level='D' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+      msg = "level='D' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
 
-      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+      expect { Logman.debug("Hello World") }.to output(msg).to_stdout_from_any_process
     end
   end
 end

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -12,41 +12,51 @@ RSpec.describe Logman do
 
   describe ".fatal" do
     it "displays a fatal message to STDOUT" do
-      msg = "level='F' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
+      msg = "level='F' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
 
-      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+      expect {
+        Logman.fatal("Hello World", :from => "shiroyasha")
+      }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".error" do
     it "displays an error message to STDOUT" do
-      msg = "level='E' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
+      msg = "level='E' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
 
-      expect { Logman.error("Hello World") }.to output(msg).to_stdout_from_any_process
+      expect {
+        Logman.error("Hello World", :from => "shiroyasha")
+      }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".warn" do
     it "displays an warning message to STDOUT" do
-      msg = "level='W' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
+      msg = "level='W' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
 
-      expect { Logman.warn("Hello World") }.to output(msg).to_stdout_from_any_process
+      expect {
+        Logman.warn("Hello World", :from => "shiroyasha")
+      }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".info" do
     it "displays an info message to STDOUT" do
-      msg = "level='I' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
+      msg = "level='I' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
 
-      expect { Logman.info("Hello World") }.to output(msg).to_stdout_from_any_process
+      expect {
+        Logman.info("Hello World", :from => "shiroyasha")
+      }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".debug" do
     it "displays a debug message to STDOUT" do
-      msg = "level='D' time='2017-12-11 09:47:27 +0000' event='Hello World'\n"
+      msg = "level='D' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
 
-      expect { Logman.debug("Hello World") }.to output(msg).to_stdout_from_any_process
+      expect {
+        Logman.debug("Hello World", :from => "shiroyasha")
+      }.to output(msg).to_stdout_from_any_process
     end
   end
 end

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -1,9 +1,13 @@
 RSpec.describe Logman do
-  around(:each) do |example|
+  around do |example|
     # make it easy to test time values in output
     Timecop.freeze(2017, 12, 11, 9, 47, 27) do
       example.run
     end
+  end
+
+  before do
+    allow(Process).to receive(:pid).and_return(1234)
   end
 
   it "has a version number" do
@@ -12,51 +16,41 @@ RSpec.describe Logman do
 
   describe ".fatal" do
     it "displays a fatal message to STDOUT" do
-      msg = "level='F' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
+      msg = "level='F' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
 
-      expect {
-        Logman.fatal("Hello World", :from => "shiroyasha")
-      }.to output(msg).to_stdout_from_any_process
+      expect { Logman.fatal("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".error" do
     it "displays an error message to STDOUT" do
-      msg = "level='E' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
+      msg = "level='E' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
 
-      expect {
-        Logman.error("Hello World", :from => "shiroyasha")
-      }.to output(msg).to_stdout_from_any_process
+      expect { Logman.error("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".warn" do
     it "displays an warning message to STDOUT" do
-      msg = "level='W' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
+      msg = "level='W' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
 
-      expect {
-        Logman.warn("Hello World", :from => "shiroyasha")
-      }.to output(msg).to_stdout_from_any_process
+      expect { Logman.warn("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".info" do
     it "displays an info message to STDOUT" do
-      msg = "level='I' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
+      msg = "level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
 
-      expect {
-        Logman.info("Hello World", :from => "shiroyasha")
-      }.to output(msg).to_stdout_from_any_process
+      expect { Logman.info("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
   end
 
   describe ".debug" do
     it "displays a debug message to STDOUT" do
-      msg = "level='D' time='2017-12-11 09:47:27 +0000' event='Hello World' from='shiroyasha'\n"
+      msg = "level='D' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
 
-      expect {
-        Logman.debug("Hello World", :from => "shiroyasha")
-      }.to output(msg).to_stdout_from_any_process
+      expect { Logman.debug("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
   end
 end

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -2,4 +2,44 @@ RSpec.describe Logman do
   it "has a version number" do
     expect(Logman::VERSION).not_to be nil
   end
+
+  describe ".fatal" do
+    it "displays a fatal message to STDOUT" do
+      msg = "level='F' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+
+      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+    end
+  end
+
+  describe ".error" do
+    it "displays an error message to STDOUT" do
+      msg = "level='E' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+
+      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+    end
+  end
+
+  describe ".warn" do
+    it "displays an warning message to STDOUT" do
+      msg = "level='W' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+
+      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+    end
+  end
+
+  describe ".info" do
+    it "displays an info message to STDOUT" do
+      msg = "level='I' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+
+      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+    end
+  end
+
+  describe ".debug" do
+    it "displays a debug message to STDOUT" do
+      msg = "level='D' time='2017-12-11 09:47:27 +0000' event='Hello World'"
+
+      expect { Logman.fatal("Hello World") }.to output(msg).to_stdout_from_any_process
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ SimpleCov.start { add_filter "/spec/" }
 
 require "bundler/setup"
 require "logman"
+require "timecop"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Severity levels are the following:

```
- FATAL
- ERROR
- WARN
- INFO
- DEBUG
```

The format of the message is the following:

```
level='F' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'
```

The severity level is reduced to one letter to keep the logs vertically aligned.

Example with one letter:

```
level='F' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'
level='F' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'
level='F' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'
```

Example with full name, lines not alligned:

```
level='FATAL' time='2017-12-11 09:47:27 +0000' pid='1234'event='Hello World' from='shiroyasha'
level='INFO' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'
level='WARN' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'
level='DEBUG' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'
```