### PR TITLE
Log JSON messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rt-logman (0.10.0)
+    rt-logman (0.11.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To log an informative message to STDOUT, use the following code snippet:
 Logman.info("Hello World")
 
 # Output:
-# level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World'
+# {"level":"INFO","time":"2017-12-12 09:33:00 +0000","pid":10950,"message":"Hello World"}
 ```
 
 Every log event can be extended with metadata — a hash with key value pairs:
@@ -30,7 +30,7 @@ Every log event can be extended with metadata — a hash with key value pairs:
 Logman.info("Hello World", :from => "renderedtext", :to => "The World")
 
 # Output:
-# level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='renderedtext' to='The World'
+# {"level":"INFO","time":"2017-12-12 09:33:21 +0000","pid":10950,"message":"Hello World","from":"renderedtext","to":"The World"}
 ```
 
 Every log event has a severity. In the previous examples we have used `info`. To
@@ -40,7 +40,7 @@ log an `error` use the following snippet:
 Logman.error("Team does not exists", :owner => "renderedtext", :team_name => "z-fightes")
 
 # Output:
-# level='E' time='2017-12-11 09:47:27 +0000' pid='1234' event='Team does not exists' owner='renderedtext' team_name='z-fighters'
+# {"level":"ERROR","time":"2017-12-12 09:33:47 +0000","pid":10950,"message":"Team does not exists","owner":"renderedtext","team_name":"z-fightes"}
 ```
 
 Logman supports multiple severity levels:
@@ -95,7 +95,7 @@ class VideoProcessor
 
     @logger.info("finished")
   rescue => exception
-    @logger.error("failed", :message => exception.message)
+    @logger.error("failed", :exception => exception.message)
 
     raise
   end
@@ -106,18 +106,18 @@ end
 In case of a successful processing of a video, we would see the following:
 
 ``` txt
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='started' id='31312' title='Keyboard Cat' component='video_processor'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='loaded into memory' component='video_processor' id='31312' title='Keyboard Cat' size='3123131312'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='compressed' component='video_processor' id='31312' title='Keyboard Cat' size='12312312'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='upload_to_s3' component='video_processor' id='31312' title='Keyboard Cat' s3_path='s3://random'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='finished' component='video_processor' id='31312' title='Keyboard Cat'
+{"level":"INFO","time":"2017-12-12 09:35:19 +0000","pid":10950,"message":"started","compoent":"video_processor","id":9312,"title":"Keyboard Cat"}
+{"level":"INFO","time":"2017-12-12 09:35:34 +0000","pid":10950,"message":"loaded into memory","compoent":"video_processor","id":9312,"title":"Keyboard Cat","size":41241241}
+{"level":"INFO","time":"2017-12-12 09:35:44 +0000","pid":10950,"message":"compressed","compoent":"video_processor","id":9312,"title":"Keyboard Cat","size":1312312}
+{"level":"INFO","time":"2017-12-12 09:36:08 +0000","pid":10950,"message":"uploaded to S3","compoent":"video_processor","id":9312,"title":"Keyboard Cat","s3_path":"s3://hehe/a.mpeg"}
+{"level":"INFO","time":"2017-12-12 09:36:27 +0000","pid":10950,"message":"finished","compoent":"video_processor","id":9312,"title":"Keyboard Cat"}
 ```
 
 In case of an error, we would see the following:
 
 ``` txt
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='started' id='31312' title='Keyboard Cat' component='video_processor'
-level='E' time='2017-12-11 09:47:27 +0000' pid='1234' event='failed' component='video_processor' id='31312' title='Keyboard Cat' message='Out of memory'
+{"level":"INFO","time":"2017-12-12 09:35:19 +0000","pid":10950,"message":"started","compoent":"video_processor","id":9312,"title":"Keyboard Cat"}
+{"level":"ERROR","time":"2017-12-12 09:35:34 +0000","pid":10950,"message":"failed","compoent":"video_processor","id":9312,"title":"Keyboard Cat","size":41241241,"exception": "Out of memory"}
 ```
 
 Logman can receive a [Ruby Logger](http://ruby-doc.org/stdlib-2.2.0/libdoc/logger/rdoc/Logger.html)
@@ -151,7 +151,7 @@ create a new Logman instance with the same fields as the previous instance:
 
 @team_api_logger.info("Hello")
 
-# level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello' version='v2'
+# {"level":"INFO","time":"2017-12-12 09:39:07 +0000","pid":10950,"message":"Hello","version":"v2"}
 ```
 
 With Logman, you can instrument data processing with a logger block. For
@@ -166,18 +166,18 @@ Logman.process("user-registration", :username => "shiroyasha") do |logger|
   logger.info("Sent signup email")
 
   team.add(user)
-  logger.info("Added user to a team", :team_id => team)
+  logger.info("Added user to a team", :team_id => team.id)
 end
 ```
 
 The above will log the following information:
 
 ``` txt
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='user-registration-started' username='shiroyasha'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='User Record Created' username='shiroyasha'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Sent signup email' username='shiroyasha'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Added user to a team' username='shiroyasha' team_id='312'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='user-registration-finished' username='shiroyasha'
+{"level":"INFO","time":"2017-12-12 09:40:39 +0000","pid":10950,"message":"user-registration-started","username":"shiroyasha"}
+{"level":"INFO","time":"2017-12-12 09:40:39 +0000","pid":10950,"message":"User Record Created","username":"shiroyasha"}
+{"level":"INFO","time":"2017-12-12 09:40:39 +0000","pid":10950,"message":"Sent signup email","username":"shiroyasha"}
+{"level":"INFO","time":"2017-12-12 09:40:39 +0000","pid":10950,"message":"Added user to a team","username":"shiroyasha","team_id":21}
+{"level":"INFO","time":"2017-12-12 09:40:39 +0000","pid":10950,"message":"user-registration-finished","username":"shiroyasha"}
 ```
 
 In case of an exception, the error will be logger and re-thrown:
@@ -198,10 +198,10 @@ end
 ```
 
 ``` ruby
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='user-registration-started' username='shiroyasha'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='User Record Created' username='shiroyasha'
-level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Sent signup email' username='shiroyasha'
-level='E' time='2017-12-11 09:47:27 +0000' pid='1234' event='user-registration-failed' username='shiroyasha' type='RuntimeError' message='Exception'
+{"level":"INFO","time":"2017-12-12 09:41:27 +0000","pid":10950,"message":"user-registration-started","username":"shiroyasha"}
+{"level":"INFO","time":"2017-12-12 09:41:27 +0000","pid":10950,"message":"User Record Created","username":"shiroyasha"}
+{"level":"INFO","time":"2017-12-12 09:41:27 +0000","pid":10950,"message":"Sent signup email","username":"shiroyasha"}
+{"level":"ERROR","time":"2017-12-12 09:41:27 +0000","pid":10950,"message":"Exception","username":"shiroyasha","type":"RuntimeError"}
 ```
 
 ## Development

--- a/lib/logman.rb
+++ b/lib/logman.rb
@@ -71,13 +71,13 @@ class Logman
   private
 
   def log(level, message, metadata = {})
-    @logger.public_send(level, { :event => message }.merge(@fields).merge(metadata))
+    @logger.public_send(level, { :message => message }.merge(@fields).merge(metadata))
   end
 
   def formatter
     proc do |severity, datetime, _progname, msg|
       event = {
-        :level => severity[0].upcase,
+        :level => severity.upcase,
         :time => datetime,
         :pid => Process.pid
       }.merge(msg)
@@ -87,6 +87,6 @@ class Logman
   end
 
   def format(event_hash)
-    event_hash.map { |key, value| "#{key}='#{value}'" }.join(" ")
+    event_hash.to_json
   end
 end

--- a/lib/logman.rb
+++ b/lib/logman.rb
@@ -1,5 +1,6 @@
 require "logman/version"
 require "logger"
+require "json"
 
 # :reek:PrimaDonnaMethod { exclude: [clear! ] }
 # :reek:TooManyStatements{ exclude: [process ] }

--- a/lib/logman/version.rb
+++ b/lib/logman/version.rb
@@ -1,3 +1,3 @@
 class Logman
-  VERSION = "0.10.0".freeze
+  VERSION = "0.11.0".freeze
 end

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 require "securerandom"
 
 # rubocop:disable Metrics/LineLength
+# rubocop:disable Style/StringLiterals
 RSpec.describe Logman do
   around do |example|
     # make it easy to test time values in output
@@ -41,11 +42,11 @@ RSpec.describe Logman do
 
     it "logs the lifecycle of a process" do
       msg = [
-        "level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='user-registration-started' username='shiroyasha'",
-        "level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='User Record Created' username='shiroyasha'",
-        "level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Sent signup email' username='shiroyasha'",
-        "level='E' time='2017-12-11 09:47:27 +0000' pid='1234' event='user-registration-failed' username='shiroyasha' type='RuntimeError' message='Exception'",
-        ""
+        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"user-registration-started","username":"shiroyasha"}',
+        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"User Record Created","username":"shiroyasha"}',
+        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Sent signup email","username":"shiroyasha"}',
+        '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Exception","username":"shiroyasha","type":"RuntimeError"}',
+        ''
       ].join("\n")
 
       expect { silent_exceptions { test_process } }.to output(msg).to_stdout_from_any_process
@@ -58,7 +59,10 @@ RSpec.describe Logman do
 
   describe ".fatal" do
     it "displays a fatal message to STDOUT" do
-      msg = "level='F' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
+      msg = [
+        '{"level":"FATAL","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        ''
+      ].join("\n")
 
       expect { Logman.fatal("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
@@ -66,7 +70,10 @@ RSpec.describe Logman do
 
   describe ".error" do
     it "displays an error message to STDOUT" do
-      msg = "level='E' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
+      msg = [
+        '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        ''
+      ].join("\n")
 
       expect { Logman.error("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
@@ -74,7 +81,10 @@ RSpec.describe Logman do
 
   describe ".warn" do
     it "displays an warning message to STDOUT" do
-      msg = "level='W' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
+      msg = [
+        '{"level":"WARN","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        ''
+      ].join("\n")
 
       expect { Logman.warn("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
@@ -82,7 +92,10 @@ RSpec.describe Logman do
 
   describe ".info" do
     it "displays an info message to STDOUT" do
-      msg = "level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
+      msg = [
+        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        ''
+      ].join("\n")
 
       expect { Logman.info("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
@@ -90,7 +103,10 @@ RSpec.describe Logman do
 
   describe ".debug" do
     it "displays a debug message to STDOUT" do
-      msg = "level='D' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='shiroyasha'\n"
+      msg = [
+        '{"level":"DEBUG","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        ''
+      ].join("\n")
 
       expect { Logman.debug("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
     end
@@ -106,7 +122,10 @@ RSpec.describe Logman do
 
     describe "#info" do
       it "displays an info message" do
-        msg = "level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='Bender' to='Fry' what='present'\n"
+        msg = [
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          ''
+        ].join("\n")
 
         expect { @logger.info("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
       end
@@ -114,7 +133,10 @@ RSpec.describe Logman do
 
     describe "#error" do
       it "displays an info message" do
-        msg = "level='E' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='Bender' to='Fry' what='present'\n"
+        msg = [
+          '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          ''
+        ].join("\n")
 
         expect { @logger.error("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
       end
@@ -122,7 +144,10 @@ RSpec.describe Logman do
 
     describe "#debug" do
       it "displays a debug message" do
-        msg = "level='D' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='Bender' to='Fry' what='present'\n"
+        msg = [
+          '{"level":"DEBUG","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          ''
+        ].join("\n")
 
         expect { @logger.debug("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
       end
@@ -130,7 +155,10 @@ RSpec.describe Logman do
 
     describe "#fatal" do
       it "displays a fatal message" do
-        msg = "level='F' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='Bender' to='Fry' what='present'\n"
+        msg = [
+          '{"level":"FATAL","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          ''
+        ].join("\n")
 
         expect { @logger.fatal("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
       end
@@ -138,7 +166,10 @@ RSpec.describe Logman do
 
     describe "#warn" do
       it "displays a warn message" do
-        msg = "level='W' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='Bender' to='Fry' what='present'\n"
+        msg = [
+          '{"level":"WARN","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          ''
+        ].join("\n")
 
         expect { @logger.warn("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
       end
@@ -148,7 +179,10 @@ RSpec.describe Logman do
       it "removes fields from the logger instance" do
         @logger.clear!
 
-        msg = "level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' what='present'\n"
+        msg = [
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","what":"present"}',
+          ''
+        ].join("\n")
 
         expect { @logger.info("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
       end
@@ -160,7 +194,10 @@ RSpec.describe Logman do
         it "copies the fields from the other instance" do
           new_logger = Logman.new(:logger => @logger)
 
-          msg = "level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' from='Bender' to='Fry' what='present'\n"
+          msg = [
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+            ''
+          ].join("\n")
 
           expect { new_logger.info("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
         end
@@ -173,7 +210,10 @@ RSpec.describe Logman do
 
           new_logger = Logman.new(:logger => logger)
 
-          msg = "level='I' time='2017-12-11 09:47:27 +0000' pid='1234' event='Hello World' what='present'\n"
+          msg = [
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","what":"present"}',
+            ''
+          ].join("\n")
 
           expect { new_logger.info("Hello World", :what => "present") }.to_not output.to_stdout_from_any_process
 


### PR DESCRIPTION
Two things changed in this Pull Request:

1. `event` field was renamed to `message`. This was in order to match the
upstream log collector service that can lookup the message field
automatically.

2. Message format was changed from key value pairs to JSON. Upstream
server can parse JSON fields, draw charts, and extract analytics from a
JSON payload.