### PR TITLE
Make Logman#process forward the result from the yielded block

### DIFF
--- a/lib/logman.rb
+++ b/lib/logman.rb
@@ -61,9 +61,11 @@ class Logman
 
     logger.info("#{name}-started")
 
-    yield(logger)
+    result = yield(logger)
 
     logger.info("#{name}-finished")
+
+    result
   rescue StandardError => exception
     logger.error("#{name}-failed", :type => exception.class.name, :message => exception.message)
     raise

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -20,40 +20,72 @@ RSpec.describe Logman do
   end
 
   describe ".process" do
+    describe "when the exception occurs withing the passed block" do
+      # rubocop:disable Lint/UnreachableCode
+      def test_process
+        Logman.process("user-registration", :username => "shiroyasha") do |logger|
+          logger.info("User Record Created")
 
-    # rubocop:disable Lint/UnreachableCode
-    def test_process
-      Logman.process("user-registration", :username => "shiroyasha") do |logger|
-        logger.info("User Record Created")
+          logger.info("Sent signup email")
 
-        logger.info("Sent signup email")
+          raise "Exception"
 
-        raise "Exception"
+          logger.info("Added user to a team", :team_id => 312)
+        end
+      end
 
-        logger.info("Added user to a team", :team_id => 312)
+      def silent_exceptions
+        yield
+      rescue StandardError
+        nil
+      end
+
+      it "logs the lifecycle of a process" do
+        message = [
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"user-registration-started","username":"shiroyasha"}',
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"User Record Created","username":"shiroyasha"}',
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Sent signup email","username":"shiroyasha"}',
+          '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Exception","username":"shiroyasha","type":"RuntimeError"}',
+          ''
+        ].join("\n")
+
+        expect { silent_exceptions { test_process } }.to output(message).to_stdout_from_any_process
+      end
+
+      it "re-raises the exception" do
+        expect { test_process }.to raise_exception(StandardError)
       end
     end
 
-    def silent_exceptions
-      yield
-    rescue StandardError
-      nil
-    end
+    describe "when the block is run without exceptions" do
+      before do
+        @block = Proc.new do |logger|
+          logger.info("User Record Created")
 
-    it "logs the lifecycle of a process" do
-      msg = [
-        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"user-registration-started","username":"shiroyasha"}',
-        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"User Record Created","username":"shiroyasha"}',
-        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Sent signup email","username":"shiroyasha"}',
-        '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Exception","username":"shiroyasha","type":"RuntimeError"}',
-        ''
-      ].join("\n")
+          logger.info("Sent signup email")
 
-      expect { silent_exceptions { test_process } }.to output(msg).to_stdout_from_any_process
-    end
+          logger.info("Added user to a team", :team_id => 312)
 
-    it "re-raises the exception" do
-      expect { test_process }.to raise_exception(StandardError)
+          :success
+        end
+      end
+
+      it "logs the lifecycle of a process" do
+        expect { Logman.process("user-registration", :username => "shiroyasha", &@block) }.to output(
+          [
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"user-registration-started","username":"shiroyasha"}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"User Record Created","username":"shiroyasha"}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Sent signup email","username":"shiroyasha"}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Added user to a team","username":"shiroyasha","team_id":312}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"user-registration-finished","username":"shiroyasha"}',
+            ''
+          ].join("\n")
+        ).to_stdout_from_any_process
+      end
+
+      it "returns the block result" do
+        expect(Logman.process("user-registration", &@block)).to eq(@block.call(Logman.new))
+      end
     end
   end
 

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Logman do
 
     describe "when the block is run without exceptions" do
       before do
-        @block = Proc.new do |logger|
+        @block = proc do |logger|
           logger.info("User Record Created")
 
           logger.info("Sent signup email")


### PR DESCRIPTION
This is the same behavior we have in Watchman#benchmark:
https://github.com/renderedtext/watchman/blob/master/lib/watchman.rb#L16-L26

This way the Logman doesn't affect the existing flow and can be injected without consequences.