### PR TITLE
Use msg instead of message

### DIFF
--- a/lib/logman.rb
+++ b/lib/logman.rb
@@ -67,14 +67,14 @@ class Logman
 
     result
   rescue StandardError => exception
-    logger.error("#{name}-failed", :type => exception.class.name, :message => exception.message)
+    logger.error("#{name}-failed", :type => exception.class.name, :msg => exception.message)
     raise
   end
 
   private
 
   def log(level, message, metadata = {})
-    @logger.public_send(level, { :message => message }.merge(@fields).merge(metadata))
+    @logger.public_send(level, { :msg => message }.merge(@fields).merge(metadata))
   end
 
   def formatter

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe Logman do
 
       it "logs the lifecycle of a process" do
         message = [
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"user-registration-started","username":"shiroyasha"}',
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"User Record Created","username":"shiroyasha"}',
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Sent signup email","username":"shiroyasha"}',
-          '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Exception","username":"shiroyasha","type":"RuntimeError"}',
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"user-registration-started","username":"shiroyasha"}',
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"User Record Created","username":"shiroyasha"}',
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Sent signup email","username":"shiroyasha"}',
+          '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Exception","username":"shiroyasha","type":"RuntimeError"}',
           ''
         ].join("\n")
 
@@ -73,11 +73,11 @@ RSpec.describe Logman do
       it "logs the lifecycle of a process" do
         expect { Logman.process("user-registration", :username => "shiroyasha", &@block) }.to output(
           [
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"user-registration-started","username":"shiroyasha"}',
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"User Record Created","username":"shiroyasha"}',
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Sent signup email","username":"shiroyasha"}',
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Added user to a team","username":"shiroyasha","team_id":312}',
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"user-registration-finished","username":"shiroyasha"}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"user-registration-started","username":"shiroyasha"}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"User Record Created","username":"shiroyasha"}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Sent signup email","username":"shiroyasha"}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Added user to a team","username":"shiroyasha","team_id":312}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"user-registration-finished","username":"shiroyasha"}',
             ''
           ].join("\n")
         ).to_stdout_from_any_process
@@ -92,7 +92,7 @@ RSpec.describe Logman do
   describe ".fatal" do
     it "displays a fatal message to STDOUT" do
       msg = [
-        '{"level":"FATAL","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        '{"level":"FATAL","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
         ''
       ].join("\n")
 
@@ -103,7 +103,7 @@ RSpec.describe Logman do
   describe ".error" do
     it "displays an error message to STDOUT" do
       msg = [
-        '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
         ''
       ].join("\n")
 
@@ -114,7 +114,7 @@ RSpec.describe Logman do
   describe ".warn" do
     it "displays an warning message to STDOUT" do
       msg = [
-        '{"level":"WARN","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        '{"level":"WARN","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
         ''
       ].join("\n")
 
@@ -125,7 +125,7 @@ RSpec.describe Logman do
   describe ".info" do
     it "displays an info message to STDOUT" do
       msg = [
-        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
         ''
       ].join("\n")
 
@@ -136,7 +136,7 @@ RSpec.describe Logman do
   describe ".debug" do
     it "displays a debug message to STDOUT" do
       msg = [
-        '{"level":"DEBUG","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"shiroyasha"}',
+        '{"level":"DEBUG","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
         ''
       ].join("\n")
 
@@ -155,7 +155,7 @@ RSpec.describe Logman do
     describe "#info" do
       it "displays an info message" do
         msg = [
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
           ''
         ].join("\n")
 
@@ -166,7 +166,7 @@ RSpec.describe Logman do
     describe "#error" do
       it "displays an info message" do
         msg = [
-          '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
           ''
         ].join("\n")
 
@@ -177,7 +177,7 @@ RSpec.describe Logman do
     describe "#debug" do
       it "displays a debug message" do
         msg = [
-          '{"level":"DEBUG","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          '{"level":"DEBUG","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
           ''
         ].join("\n")
 
@@ -188,7 +188,7 @@ RSpec.describe Logman do
     describe "#fatal" do
       it "displays a fatal message" do
         msg = [
-          '{"level":"FATAL","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          '{"level":"FATAL","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
           ''
         ].join("\n")
 
@@ -199,7 +199,7 @@ RSpec.describe Logman do
     describe "#warn" do
       it "displays a warn message" do
         msg = [
-          '{"level":"WARN","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+          '{"level":"WARN","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
           ''
         ].join("\n")
 
@@ -212,7 +212,7 @@ RSpec.describe Logman do
         @logger.clear!
 
         msg = [
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","what":"present"}',
+          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","what":"present"}',
           ''
         ].join("\n")
 
@@ -227,7 +227,7 @@ RSpec.describe Logman do
           new_logger = Logman.new(:logger => @logger)
 
           msg = [
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","from":"Bender","to":"Fry","what":"present"}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
             ''
           ].join("\n")
 
@@ -243,7 +243,7 @@ RSpec.describe Logman do
           new_logger = Logman.new(:logger => logger)
 
           msg = [
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"message":"Hello World","what":"present"}',
+            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","what":"present"}',
             ''
           ].join("\n")
 


### PR DESCRIPTION
"Message" field  has special semantics on our logging backend. Using "msg" instead.