### PR TITLE
Simple, position based, logging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rt-logman (1.1.0)
+    rt-logman (1.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/logman.rb
+++ b/lib/logman.rb
@@ -74,28 +74,15 @@ class Logman
   private
 
   def log(level, message, metadata = {})
-    @logger.public_send(level, { :msg => message }.merge(@fields).merge(metadata))
+    meta = @fields.merge(metadata).map { |k, v| "#{k}: '#{v}'" }.join(", ")
+
+    @logger.public_send(level, "#{message} -- #{meta}")
   end
 
   def formatter
     proc do |severity, datetime, _progname, msg|
-      event = {
-        :level => severity.upcase,
-        :time => datetime,
-        :pid => Process.pid
-      }
-
-      if msg.is_a?(Hash)
-        event.merge!(msg)
-      else
-        event[:msg] = msg.to_s
-      end
-
-      "#{format(event)}\n"
+      "#{severity.upcase} [#{datetime.strftime("%H:%M:%S.%3N")} ##{Process.pid}] -- #{msg}\n"
     end
   end
 
-  def format(event_hash)
-    event_hash.to_json
-  end
 end

--- a/lib/logman.rb
+++ b/lib/logman.rb
@@ -74,7 +74,7 @@ class Logman
   private
 
   def log(level, message, metadata = {})
-    meta = @fields.merge(metadata).map { |k, v| "#{k}: '#{v}'" }.join(", ")
+    meta = @fields.merge(metadata).map { |key, val| "#{key}: '#{val}'" }.join(", ")
 
     @logger.public_send(level, "#{message} -- #{meta}")
   end

--- a/lib/logman/version.rb
+++ b/lib/logman/version.rb
@@ -1,3 +1,3 @@
 class Logman
-  VERSION = "1.1.0".freeze
+  VERSION = "1.2.0".freeze
 end

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe Logman do
 
       it "logs the lifecycle of a process" do
         message = [
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"user-registration-started","username":"shiroyasha"}',
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"User Record Created","username":"shiroyasha"}',
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Sent signup email","username":"shiroyasha"}',
-          '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Exception","username":"shiroyasha","type":"RuntimeError"}',
-          ''
+           "INFO [09:47:27.000 #1234] -- user-registration-started -- username: 'shiroyasha'",
+           "INFO [09:47:27.000 #1234] -- User Record Created -- username: 'shiroyasha'",
+           "INFO [09:47:27.000 #1234] -- Sent signup email -- username: 'shiroyasha'",
+           "ERROR [09:47:27.000 #1234] -- user-registration-failed -- username: 'shiroyasha', type: 'RuntimeError', msg: 'Exception'",
+           ""
         ].join("\n")
 
         expect { silent_exceptions { test_process } }.to output(message).to_stdout_from_any_process
@@ -80,12 +80,12 @@ RSpec.describe Logman do
       it "logs the lifecycle of a process" do
         expect { Logman.process("user-registration", :username => "shiroyasha", &@block) }.to output(
           [
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"user-registration-started","username":"shiroyasha"}',
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"User Record Created","username":"shiroyasha"}',
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Sent signup email","username":"shiroyasha"}',
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Added user to a team","username":"shiroyasha","team_id":312}',
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"user-registration-finished","username":"shiroyasha"}',
-            ''
+            "INFO [09:47:27.000 #1234] -- user-registration-started -- username: 'shiroyasha'",
+            "INFO [09:47:27.000 #1234] -- User Record Created -- username: 'shiroyasha'",
+            "INFO [09:47:27.000 #1234] -- Sent signup email -- username: 'shiroyasha'",
+            "INFO [09:47:27.000 #1234] -- Added user to a team -- username: 'shiroyasha', team_id: '312'",
+            "INFO [09:47:27.000 #1234] -- user-registration-finished -- username: 'shiroyasha'",
+            ""
           ].join("\n")
         ).to_stdout_from_any_process
       end
@@ -99,8 +99,8 @@ RSpec.describe Logman do
   describe ".fatal" do
     it "displays a fatal message to STDOUT" do
       msg = [
-        '{"level":"FATAL","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
-        ''
+        "FATAL [09:47:27.000 #1234] -- Hello World -- from: 'shiroyasha'",
+        ""
       ].join("\n")
 
       expect { Logman.fatal("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
@@ -110,8 +110,8 @@ RSpec.describe Logman do
   describe ".error" do
     it "displays an error message to STDOUT" do
       msg = [
-        '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
-        ''
+        "ERROR [09:47:27.000 #1234] -- Hello World -- from: 'shiroyasha'",
+        ""
       ].join("\n")
 
       expect { Logman.error("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
@@ -121,8 +121,8 @@ RSpec.describe Logman do
   describe ".warn" do
     it "displays an warning message to STDOUT" do
       msg = [
-        '{"level":"WARN","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
-        ''
+        "WARN [09:47:27.000 #1234] -- Hello World -- from: 'shiroyasha'",
+        ""
       ].join("\n")
 
       expect { Logman.warn("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
@@ -132,8 +132,8 @@ RSpec.describe Logman do
   describe ".info" do
     it "displays an info message to STDOUT" do
       msg = [
-        '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
-        ''
+        "INFO [09:47:27.000 #1234] -- Hello World -- from: 'shiroyasha'",
+        ""
       ].join("\n")
 
       expect { Logman.info("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
@@ -143,8 +143,8 @@ RSpec.describe Logman do
   describe ".debug" do
     it "displays a debug message to STDOUT" do
       msg = [
-        '{"level":"DEBUG","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"shiroyasha"}',
-        ''
+        "DEBUG [09:47:27.000 #1234] -- Hello World -- from: 'shiroyasha'",
+        ""
       ].join("\n")
 
       expect { Logman.debug("Hello World", :from => "shiroyasha") }.to output(msg).to_stdout_from_any_process
@@ -162,8 +162,8 @@ RSpec.describe Logman do
     describe "#info" do
       it "displays an info message" do
         msg = [
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
-          ''
+          "INFO [09:47:27.000 #1234] -- Hello World -- from: 'Bender', to: 'Fry', what: 'present'",
+          ""
         ].join("\n")
 
         expect { @logger.info("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
@@ -173,8 +173,8 @@ RSpec.describe Logman do
     describe "#error" do
       it "displays an info message" do
         msg = [
-          '{"level":"ERROR","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
-          ''
+          "ERROR [09:47:27.000 #1234] -- Hello World -- from: 'Bender', to: 'Fry', what: 'present'",
+          ""
         ].join("\n")
 
         expect { @logger.error("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
@@ -184,8 +184,8 @@ RSpec.describe Logman do
     describe "#debug" do
       it "displays a debug message" do
         msg = [
-          '{"level":"DEBUG","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
-          ''
+          "DEBUG [09:47:27.000 #1234] -- Hello World -- from: 'Bender', to: 'Fry', what: 'present'",
+          ""
         ].join("\n")
 
         expect { @logger.debug("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
@@ -195,8 +195,8 @@ RSpec.describe Logman do
     describe "#fatal" do
       it "displays a fatal message" do
         msg = [
-          '{"level":"FATAL","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
-          ''
+          "FATAL [09:47:27.000 #1234] -- Hello World -- from: 'Bender', to: 'Fry', what: 'present'",
+          ""
         ].join("\n")
 
         expect { @logger.fatal("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
@@ -206,8 +206,8 @@ RSpec.describe Logman do
     describe "#warn" do
       it "displays a warn message" do
         msg = [
-          '{"level":"WARN","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
-          ''
+          "WARN [09:47:27.000 #1234] -- Hello World -- from: 'Bender', to: 'Fry', what: 'present'",
+          ""
         ].join("\n")
 
         expect { @logger.warn("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
@@ -219,8 +219,8 @@ RSpec.describe Logman do
         @logger.clear!
 
         msg = [
-          '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","what":"present"}',
-          ''
+          "INFO [09:47:27.000 #1234] -- Hello World -- what: 'present'",
+          ""
         ].join("\n")
 
         expect { @logger.info("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
@@ -234,8 +234,8 @@ RSpec.describe Logman do
           new_logger = Logman.new(:logger => @logger)
 
           msg = [
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","from":"Bender","to":"Fry","what":"present"}',
-            ''
+            "INFO [09:47:27.000 #1234] -- Hello World -- from: 'Bender', to: 'Fry', what: 'present'",
+            ""
           ].join("\n")
 
           expect { new_logger.info("Hello World", :what => "present") }.to output(msg).to_stdout_from_any_process
@@ -250,8 +250,8 @@ RSpec.describe Logman do
           new_logger = Logman.new(:logger => logger)
 
           msg = [
-            '{"level":"INFO","time":"2017-12-11 09:47:27 +0000","pid":1234,"msg":"Hello World","what":"present"}',
-            ''
+            "INFO [09:47:27.000 #1234] -- Hello World -- what: 'present'",
+            ""
           ].join("\n")
 
           expect { new_logger.info("Hello World", :what => "present") }.to_not output.to_stdout_from_any_process

--- a/spec/logman_spec.rb
+++ b/spec/logman_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 require "securerandom"
 
 # rubocop:disable Metrics/LineLength
-# rubocop:disable Style/StringLiterals
 RSpec.describe Logman do
   around do |example|
     # make it easy to test time values in output
@@ -49,11 +48,11 @@ RSpec.describe Logman do
 
       it "logs the lifecycle of a process" do
         message = [
-           "INFO [09:47:27.000 #1234] -- user-registration-started -- username: 'shiroyasha'",
-           "INFO [09:47:27.000 #1234] -- User Record Created -- username: 'shiroyasha'",
-           "INFO [09:47:27.000 #1234] -- Sent signup email -- username: 'shiroyasha'",
-           "ERROR [09:47:27.000 #1234] -- user-registration-failed -- username: 'shiroyasha', type: 'RuntimeError', msg: 'Exception'",
-           ""
+          "INFO [09:47:27.000 #1234] -- user-registration-started -- username: 'shiroyasha'",
+          "INFO [09:47:27.000 #1234] -- User Record Created -- username: 'shiroyasha'",
+          "INFO [09:47:27.000 #1234] -- Sent signup email -- username: 'shiroyasha'",
+          "ERROR [09:47:27.000 #1234] -- user-registration-failed -- username: 'shiroyasha', type: 'RuntimeError', msg: 'Exception'",
+          ""
         ].join("\n")
 
         expect { silent_exceptions { test_process } }.to output(message).to_stdout_from_any_process


### PR DESCRIPTION
JSON log format has some benefits if the upsteam provider can parse and provide additional context.
In our case, the additional context is not so significant. 

On the other hand, the added verbosity of a JSON message has dissandvantages when it comes the size of the messages. It requeres almost twice as many bytes to transmit it as a JSON message. We pay per bytes used, so I think it is better to optimize for that.

JSON is also harder to read, compared to positional log formats.